### PR TITLE
Setup blog writing workflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "jest-resolve": "26.6.0",
     "jest-watch-typeahead": "0.6.1",
     "jwt-decode": "3.1.2",
-    "lodash-es": "^4.17.21",
+    "lodash-es": "4.17.21",
     "mini-css-extract-plugin": "0.11.3",
     "node-sass": "6.0.1",
     "npm": "^8.1.2",

--- a/src/config/endpoints.ts
+++ b/src/config/endpoints.ts
@@ -5,5 +5,6 @@ export enum Endpoints {
   AUTHORS = 'Authors',
   AUTH = 'Auth',
   LOGIN = 'Login',
-  REGISTER = 'Register'
+  REGISTER = 'Register',
+  USERS = 'Users',
 }

--- a/src/hooks/useAuthUser.ts
+++ b/src/hooks/useAuthUser.ts
@@ -1,0 +1,40 @@
+import axios from 'axios';
+import { useEffect, useState } from 'react';
+import { Endpoints } from '../config';
+import { JWT_TOKEN_KEY } from '../store/auth/constants';
+import { AuthUser } from '../types/models';
+import decodeJwtToken from '../utils/decodeJwtToken';
+import retrieveFromLocalStorage from '../utils/retrieveFromLocalStorage';
+
+const useAuthUser = (): AuthUser => {
+  const [user, setUser] = useState<AuthUser>({
+    authorId: '',
+    email: '',
+    firstName: '',
+    id: '',
+    lastName: '',
+  });
+
+  useEffect(() => {
+    const jwtToken = retrieveFromLocalStorage(JWT_TOKEN_KEY);
+
+    if (jwtToken) {
+      const jwtUserInfo = decodeJwtToken(jwtToken);
+      const userId = (jwtUserInfo as any).UserId;
+
+      const fetchUserEndpoint = `${Endpoints.ROOT}/${Endpoints.USERS}/${userId}`;
+
+      axios.get(fetchUserEndpoint)
+        .then((res) => {
+          setUser(res.data.payload);
+        })
+        .catch((err) => {
+          console.error(`There was an issue retrieving the current user: ${err}`);
+        });
+    }
+  }, []);
+
+  return user;
+};
+
+export default useAuthUser;

--- a/src/store/auth/types.ts
+++ b/src/store/auth/types.ts
@@ -3,6 +3,7 @@ export type AuthUser = {
   firstName: string;
   lastName: string;
   email: string;
+  authorId: string;
 };
 
 export type LoginCredentials = {

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -45,3 +45,11 @@ export interface Publication {
   name: string;
   owner: Author;
 }
+
+export interface AuthUser {
+  id: string;
+  firstName: string;
+  lastName: string;
+  email: string;
+  authorId: string;
+}

--- a/src/utils/isObjectEmpty.ts
+++ b/src/utils/isObjectEmpty.ts
@@ -1,0 +1,4 @@
+// eslint-disable-next-line max-len
+const isObjectEmpty = (object: Record<string, any>) => Object.keys(object).length === 0;
+
+export default isObjectEmpty;

--- a/src/views/write-blog/WriteBlog.tsx
+++ b/src/views/write-blog/WriteBlog.tsx
@@ -1,51 +1,98 @@
-import { useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import styles from './write-blog.module.scss';
 import {
   Navbar,
   Editor,
 } from './components';
 import BalloonEditor from '@ckeditor/ckeditor5-editor-balloon/src/ballooneditor';
+import extractBlogTitle from './utils/extractBlogTitle';
+import retrieveFromLocalStorage from 'src/utils/retrieveFromLocalStorage';
+import { JWT_TOKEN_KEY } from 'src/store/auth/constants';
+import useAuthUser from 'src/hooks/useAuthUser';
+import extractBlogContentWithoutTitle from './utils/extractBlogContentWithoutTitle';
+import axios from 'axios';
+import { Endpoints } from 'src/config';
+import { AuthUser } from 'src/types/models';
 
 interface EditorEvent {
   id: string;
   data?: string;
   editor?: any;
-  evtName: string;
 }
 
 export default function WriteBlog(): JSX.Element {
   const editorRef = useRef<BalloonEditor | null>();
 
+  // Storing values in ref in order to prevent them from being cleared before unmount.
+  const blogTitleRef = useRef('');
+  const blogContentRef = useRef('');
+  const authorIdRef = useRef('');
+
+  // We'll always have access to the token from this view
+  const jwtToken = String(retrieveFromLocalStorage(JWT_TOKEN_KEY));
+
+  const createBlogEndpoint = `${Endpoints.ROOT}/${Endpoints.BLOGS}`;
+
+  const user: Record<string, string> | AuthUser = useAuthUser();
+
   // Setting the editor ref
-  const handleEditorReady = ({
-    id,
-    editor,
-    evtName,
-  }: EditorEvent) => {
+  const handleEditorReady = ({ editor }: EditorEvent) => {
     editorRef.current = editor;
-    console.log(id, editor, evtName);
   };
 
   const handleEditorError = ({
     id,
     editor,
-    evtName,
   }: EditorEvent) => {
-    console.log(id, editor, evtName);
+    console.log(id, editor);
   };
 
-  const handleEditorUnmounted = ({
-    id,
-    editor,
-    evtName,
-  }: EditorEvent) => {
-    console.log(id, editor, evtName);
+  const createDraftBlog = (): void => {
+    axios.post(
+      createBlogEndpoint,
+      {
+        title: blogTitleRef.current,
+        content: blogContentRef.current,
+        authorId: authorIdRef.current,
+      },
+      {
+        // Will test Authorization functionality in the near future.
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: jwtToken,
+        },
+      },
+    );
   };
 
   // Getting the editor ref's data
   const handleSaveEditorContent = (): void => {
-    console.log(editorRef.current?.getData());
+    if (editorRef.current) {
+      const title = extractBlogTitle(editorRef.current.sourceElement);
+      const content = editorRef.current.getData();
+
+      const contentWithoutTitle = extractBlogContentWithoutTitle(content);
+
+      blogTitleRef.current = title || '';
+      blogContentRef.current = contentWithoutTitle;
+    }
   };
+
+  useEffect(() => {
+    authorIdRef.current = user.authorId;
+  }, [user]);
+
+  useEffect(() => () => {
+    // Currently we are only retrieving data from the editor at unmount time,
+    // but we might consider doing so at set intervals
+    // or when it's being updated in order to prevent any accidental loss due to unforeseen events
+    handleSaveEditorContent();
+
+    // We'll only create a new article if there's either a title or any content.
+    if (blogTitleRef.current || blogContentRef.current) {
+      createDraftBlog();
+    }
+  }, []);
 
   return (
     <div className={styles['write-blog']}>
@@ -56,7 +103,6 @@ export default function WriteBlog(): JSX.Element {
         <Editor
           handleEditorReady={handleEditorReady}
           handleEditorError={handleEditorError}
-          handleEditorUnmounted={handleEditorUnmounted}
         />
       </div>
     </div>

--- a/src/views/write-blog/utils/extractBlogContentWithoutTitle.ts
+++ b/src/views/write-blog/utils/extractBlogContentWithoutTitle.ts
@@ -1,0 +1,4 @@
+// eslint-disable-next-line no-useless-escape
+const extractBlogContentWithoutTitle = (blogContent: string): string => blogContent.replace('/\<h1(.*)\>(.*)\<\/h1\>/', '');
+
+export default extractBlogContentWithoutTitle;

--- a/src/views/write-blog/utils/extractBlogTitle.ts
+++ b/src/views/write-blog/utils/extractBlogTitle.ts
@@ -1,0 +1,9 @@
+const extractBlogTitle = (blogContainerElement: HTMLElement | undefined): string | null => {
+  if (!blogContainerElement) return null;
+
+  const headerElement = blogContainerElement.querySelector('h1');
+
+  return headerElement?.textContent || null;
+};
+
+export default extractBlogTitle;

--- a/yarn.lock
+++ b/yarn.lock
@@ -8766,7 +8766,7 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
-lodash-es@^4.17.11, lodash-es@^4.17.15, lodash-es@^4.17.21:
+lodash-es@4.17.21, lodash-es@^4.17.11, lodash-es@^4.17.15:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
   integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==


### PR DESCRIPTION
- Enable the creation of draft blogs
- Setup editor onChange event callback prop handler
- Create `useAuthUser` hook to enable the retrieval of the currently authenticated user
- Update `AuthUser` type to match the latest changes made to the backend whilst retrieving the data about the current user (DTO)
- Setup utils to facilitate the retrieval of the blog's title (without content) & content (without title)  -> Might require some adjustments later down the road